### PR TITLE
Add fix for old glibc

### DIFF
--- a/ImarisConvertBioformats/main/bpLogger.cxx
+++ b/ImarisConvertBioformats/main/bpLogger.cxx
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 
+
 #include "bpLogger.h"
 
 #include "../src/bpWriterCommonHeaders.h"
@@ -40,6 +41,11 @@
 #elif defined(__linux__)
 #include <unistd.h>
 #include <sys/types.h>
+#endif
+
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
 #endif
 
 


### PR DESCRIPTION
Fix for compiling with glibc < 2.30. See discussion here:
https://stackoverflow.com/questions/30680550/c-gettid-was-not-declared-in-this-scope/30681498#30681498