### PR TITLE
Fix FreeImage library detection for linux

### DIFF
--- a/ImarisConvertBioformats/CMakeLists.txt
+++ b/ImarisConvertBioformats/CMakeLists.txt
@@ -117,7 +117,7 @@ include_directories(${SUBDIR_LIBS}/fileiobioformats)
 
 #set(FreeImage_ROOT $(FreeImage_ROOT) CACHE PATH "Search path for the FreeImage libraries")
 find_library(FreeImage_LIBRARIES 
-                 NAMES FreeImage libfreeimage
+                 NAMES FreeImage freeimage
                  PATHS ${FreeImage_ROOT}/lib
                  NO_DEFAULT_PATH)
 

--- a/ImarisConvertBioformats/CMakeLists.txt
+++ b/ImarisConvertBioformats/CMakeLists.txt
@@ -117,7 +117,7 @@ include_directories(${SUBDIR_LIBS}/fileiobioformats)
 
 #set(FreeImage_ROOT $(FreeImage_ROOT) CACHE PATH "Search path for the FreeImage libraries")
 find_library(FreeImage_LIBRARIES 
-                 NAMES FreeImage
+                 NAMES FreeImage libfreeimage
                  PATHS ${FreeImage_ROOT}/lib
                  NO_DEFAULT_PATH)
 


### PR DESCRIPTION
It tends to be called `libfreeimage.so` on Linux, hence we need to look for the lower case version. This seems to fix the compilation on my Linux setup.